### PR TITLE
feat(cleanup): mass removal of obsolete usernames and auto-delete non-reciprocals (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 
 ### Maintainer-only
 
-* Local scripts (`.env`, `scripts/cleaner.py`, `scripts/gitgrow.py` for local runs).
+* Local scripts (`.env`, `scripts/duplicates.py`, `scripts/gitgrow.py` for local runs).
 * Manual workflows (`manual_follow.yml`, `manual_unfollow.yml`).
 * Stargazer shoutouts workflow is for repo analytics/discussion, not for general users.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The motto **“You only get what you give”** drives GitGrowBot’s behavior:
   - Duplicates and dead accounts are continuously pruned and removed.
   - Unfollows non-reciprocals.  
   - Skips any usernames you whitelist.  
-- **Cleaner utility** (`scripts/cleaner.py`)  
+- **Cleaner utility** (`scripts/duplicates.py`)  
   - Deduplicates and prunes dead GitHub usernames locally.  
 - **Offline logging**  
   - Records missing usernames in `logs/offline_usernames-<timestamp>.txt`.  
@@ -47,7 +47,7 @@ The motto **“You only get what you give”** drives GitGrowBot’s behavior:
   - `.env` support for local testing (optional).  
 - **Modular code**  
   - `scripts/gitgrow.py` for main logic.  
-  - `scripts/cleaner.py` for list maintenance. 
+  - `scripts/duplicates.py` for list maintenance. 
   - `scripts/integrity.py` for users existence check.
   - `scripts/orgs.py` for optional org member targeting (deprecated, see [CHANGELOG.md](./CHANGELOG.md))
   - `scripts/autotrack.py` tracks all unique stargazers across your repos, logs "unstargazers," and updates `.github/state/stargazer_state.json` (persisted to the `tracker-data` branch).
@@ -88,14 +88,14 @@ You can join this list too—see below (**⭐ & Join more than 91,000 users!**).
 
 ## Local testing
 
-If you want to test the bot locally, you can use the provided `scripts/cleaner.py` and `scripts/gitgrow.py` scripts.
+If you want to test the bot locally, you can use the provided `scripts/duplicates.py` and `scripts/gitgrow.py` scripts.
 
 1. Copy `.env.example` → `.env` and fill in your PAT.
 2. Run the following commands:
 
 ```bash
 # Example local run of cleanup
-python scripts/cleaner.py
+python scripts/duplicates.py
 
 # Example local dry-run of follow bot
 python scripts/gitgrow.py
@@ -146,7 +146,7 @@ Let's grow! 💪
 ├── scripts
 │   ├── gitgrow.py                    # Main follow/unfollow driver
 │   ├── unfollowers.py                # Unfollow-only logic
-│   ├── cleaner.py                    # Username list maintenance
+│   ├── duplicates.py                    # Username list maintenance
 │   ├── integrity.py                  # Username existence check and cleaning
 │   ├── autostarback.py               # Stargazer reciprocity logic: stars/un-stars
 │   ├── autotrack.py                  # Stargazer tracker/state generator (called by autostarback.py)
@@ -154,7 +154,7 @@ Let's grow! 💪
 ├── tests
 │   ├── test_bot_core_behavior.py     # follow/unfollow/follow-back
 │   ├── test_unfollowers.py           # unfollow-only logic
-│   └── test_cleaner.py              # cleaner dedupe + missing-user removal
+│   └── test_duplicates.py              # cleaner dedupe + missing-user removal
 ```
 
 ### Manual Troubleshooting Runners (optional)

--- a/scripts/duplicates.py
+++ b/scripts/duplicates.py
@@ -1,4 +1,4 @@
-# cleaner.py
+# duplicates.py
 #!/usr/bin/env python3
 import sys
 import pathlib

--- a/tests/test_cleaner.py
+++ b/tests/test_cleaner.py
@@ -1,5 +1,0 @@
-# tests/test_cleaner.py
-# Unit tests for cleaner.py are deferred due to performance issues.
-# The logic in cleaner.py is slow and requires optimization.
-# Tests will be implemented after refactoring cleaner.py.
-# TODO: Optimize cleaner.py, then add tests.

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -1,0 +1,5 @@
+# tests/test_duplicates.py
+# Unit tests for duplicates.py are deferred due to performance issues.
+# The logic in duplicates.py is slow and requires optimization.
+# Tests will be implemented after refactoring duplicates.py.
+# TODO: Optimize duplicates.py, then add tests.


### PR DESCRIPTION
### What
- Performing a **mass cleanup** of `config/usernames.txt` to remove obsolete, duplicate, or absent entries originating from old aggregated lists.
- Starting to work on a new script `scripts/cleanup_usernames.py` to handle automatic deletion when:
  - A removal request is received, or
  - A user does not reciprocate the follow within a reasonable timeframe.
- Renamed `scripts/cleaner.py` to `scripts/duplicates.py` (dedicated to duplicate detection only).

### Why
- Addresses #42.
- Keeps `usernames.txt` accurate, avoids spamming users, and respects privacy.
- Splits responsibilities clearly between:
  - **duplicates.py** = duplicate detection
  - **cleanup_usernames.py** = user-requested or non-reciprocating removals + manual bulk deletion

### How
- Removed outdated entries from `usernames.txt` in one pass.
- Added initial version of cleanup script with backup and dry-run support.
- Updated `README` and `CHANGELOG` to reflect the new structure.

### Status
Work in progress

### Expected outcome
- GitGrow is free of obsolete, duplicate, or absent entries originating from old aggregated lists
- GitGrow deletes users who do not reciprocate
- GitGrow opens PR on `main` when a user opens an issue for a removal request